### PR TITLE
Add --authenticator webroot

### DIFF
--- a/certbot.md
+++ b/certbot.md
@@ -24,15 +24,15 @@ certbot certificates
 ```
 **Request a certificate**
 ```
-certbot certonly -d example.com,www.example.com
+certbot certonly --authenticator webroot -d example.com,www.example.com
 ```
 **Expand existing certificate**
 ```
-certbot certonly --expand -d example.com,www.example.com,sub1.example.com
+certbot certonly --authenticator webroot --expand -d example.com,www.example.com,sub1.example.com
 ```
 **Force renew a certificate**
 ```
-certbot certonly --force-renewal --cert-name example.com
+certbot certonly --authenticator webroot --force-renewal --cert-name example.com
 ```
 **Delete a certificate**
 ```


### PR DESCRIPTION
Always use `--authenticator webroot` when requesting a new certificate with the webroot authenticator. This is required because the default webroot authenticator has been removed from (new) cli.ini configurations.